### PR TITLE
Parameterize Python version

### DIFF
--- a/custom-image/Dockerfile
+++ b/custom-image/Dockerfile
@@ -1,4 +1,6 @@
-FROM --platform=linux/arm/v7 python:3.12.0-slim-bullseye as builder
+ARG PYTHON_VERSION=3.12.0
+
+FROM --platform=linux/arm/v7 python:${PYTHON_VERSION}-slim-bullseye as builder
 
 # Upgrade pip
 RUN python -m pip install --upgrade pip

--- a/custom-image/README.md
+++ b/custom-image/README.md
@@ -21,10 +21,12 @@ Python 3.12 をインストールしたイメージをビルドし、そのイ�
 ```bash
 cd custom-image
 # イメージのビルド (時間がかかります)
-docker buildx build --platform linux/amd64 -t ghcr.io/idein/custom-image-example --load .
+docker buildx build --platform linux/amd64 --build-arg PYTHON_VERSION=3.12.0 -t ghcr.io/idein/custom-image-example --load .
 ```
 
 `.actdk/dependencies.json` に `base_image` として `ghcr.io/idein/custom-image-example` が指定されており、`actdk build --release` や `actdk upload` ではここでビルドしたイメージが使われます。
+
+`--build-arg PYTHON_VERSION=3.12.0` を変更することで、インストールする Python のバージョンを変更することができます。
 
 ## Actsim での動作確認
 


### PR DESCRIPTION
カスタムイメージの例で、インストールする Python のバージョンを `--build-arg PYTHON_VERSION=...` によって変更できるようにしました。