### PR TITLE
libdrm2 を dependencies.json から削除する

### DIFF
--- a/imagenet-classification-for-aicast/.actdk/dependencies.json
+++ b/imagenet-classification-for-aicast/.actdk/dependencies.json
@@ -14,7 +14,7 @@
     "pip": ["actfw-raspberrypi==3.1.0"]
   },
   "raspberrypi-bullseye": {
-    "apt": ["libraspberrypi0", "libdrm2"],
+    "apt": ["libraspberrypi0"],
     "pip": ["actfw-raspberrypi==3.1.0"]
   }
 }

--- a/imagenet-classification-for-raspi/.actdk/dependencies.json
+++ b/imagenet-classification-for-raspi/.actdk/dependencies.json
@@ -17,8 +17,7 @@
   },
   "raspberrypi-bullseye": {
     "apt": [
-      "libraspberrypi0",
-      "libdrm2"
+      "libraspberrypi0"
     ],
     "pip": [
       "actfw-raspberrypi"


### PR DESCRIPTION
- examples の dependencies.json から libdrm を削除する

https://www.notion.so/idein-inc/examples-dependencies-json-libdrm-fbf8ef790d6e4769823276a176bd089c?pvs=4