### PR TITLE
Update: actfw-core used in imagenet-classification-for-aicast to 2.6.0

### DIFF
--- a/imagenet-classification-for-aicast/.actdk/dependencies.json
+++ b/imagenet-classification-for-aicast/.actdk/dependencies.json
@@ -8,7 +8,7 @@
     "fbset",
     "fonts-dejavu-core"
   ],
-  "pip": ["actfw-core==2.4.0"],
+  "pip": ["actfw-core==2.6.0"],
   "raspberrypi-buster": {
     "apt": ["libraspberrypi0"],
     "pip": ["actfw-raspberrypi==3.1.0"]


### PR DESCRIPTION
imagenet-classification-for-aicast の依存する actfw-core を 2.6.0 に更新します。
これ以前のバージョンで Device Log 出力されていた以下のような警告メッセージが出力されなくなります。
> libv4lcontrol: error querying device capabilities: Inappropriate ioctl for device