### PR TITLE
fix: remove stop from presenter

### DIFF
--- a/amazon-kinesis-video-streams/app/presenter.py
+++ b/amazon-kinesis-video-streams/app/presenter.py
@@ -77,11 +77,6 @@ class Presenter(Consumer):
 
         self.kvssink = kvssink
 
-    def stop(self):
-        """Stop the activity"""
-        if self.kvssink is not None:
-            self.kvssink.stop()
-
     def proc(self, captured_image):
         current_time = time.time()
         result_image = captured_image.copy()


### PR DESCRIPTION
### やりたいこと
- presenterのstop()の実装が不適切でpresenterのis_runningがfalseにならないようになっている
- このせいでactfw_coreのApplicationがstopしてもpresenterがstopしなくなっている
- presenterのstopを削除し、継承元のstop()が呼ばれるようにしたい