### PR TITLE
Fix runtime error of i2c-sensor

### DIFF
--- a/i2c-sensor/app/main
+++ b/i2c-sensor/app/main
@@ -1,90 +1,109 @@
 #!/usr/bin/python3
 import actfw_core
+from actfw_core.task import Isolated
 import time
 import smbus2  # require pip install
 from sensor.VEML7700 import VEML7700
 from sensor.SHT3x import SHT3x
 from sensor.Omron2smpd02e import Omron2smpd02e
 
-addr_veme7700 = 0x10
-addr_SHT3x = 0x44
-addr_2SMPB = 0x70
-invalid_sensor_count = 0
-try:
-    sensor_VEML7700 = VEML7700(addr_veme7700)
-except Exception as e:
-    actfw_core.notify([{'invalid_sensors': 'VEML7700'}])
-    actfw_core.notify([{'i2cerror': str(e)}])
-    invalid_sensor_count += 1
 
-try:
-    sensor_SHT3x = SHT3x(addr_SHT3x)
-except Exception as e:
-    actfw_core.notify([{'invalid_sensors': 'SHT3x'}])
-    actfw_core.notify([{'i2cerror': str(e)}])
-    invalid_sensor_count += 1
+class Reader(Isolated):
+    def __init__(self, interval):
+        super().__init__()
+        self.interval = interval
 
-try:
-    sensor_Omron2smpd02e = Omron2smpd02e(addr_2SMPB)
-except Exception as e:
-    actfw_core.notify([{'invalid_sensors': 'Omron2smpd02e'}])
-    actfw_core.notify([{'i2cerror': str(e)}])
-    invalid_sensor_count += 1
+        addr_veme7700 = 0x10
+        addr_SHT3x = 0x44
+        addr_2SMPB = 0x70
+        invalid_sensor_count = 0
+        try:
+            self.sensor_VEML7700 = VEML7700(addr_veme7700)
+        except Exception as e:
+            actfw_core.notify([{"invalid_sensors": "VEML7700"}])
+            actfw_core.notify([{"i2cerror": str(e)}])
+            invalid_sensor_count += 1
 
-if invalid_sensor_count == 3:
-    actfw_core.notify([{'HAT_Error': 'Errors were detected in all sensors. There might be no HAT sensor connected, or the \'Enable I2C\' setting in the actcast writer\'s Advanced Settings might not be turned on.'}])
+        try:
+            self.sensor_SHT3x = SHT3x(addr_SHT3x)
+        except Exception as e:
+            actfw_core.notify([{"invalid_sensors": "SHT3x"}])
+            actfw_core.notify([{"i2cerror": str(e)}])
+            invalid_sensor_count += 1
+
+        try:
+            self.sensor_Omron2smpd02e = Omron2smpd02e(addr_2SMPB)
+        except Exception as e:
+            actfw_core.notify([{"invalid_sensors": "Omron2smpd02e"}])
+            actfw_core.notify([{"i2cerror": str(e)}])
+            invalid_sensor_count += 1
+
+        if invalid_sensor_count == 3:
+            actfw_core.notify(
+                [
+                    {
+                        "HAT_Error": "Errors were detected in all sensors. There might be no HAT sensor connected, or the 'Enable I2C' setting in the actcast writer's Advanced Settings might not be turned on."
+                    }
+                ]
+            )
+
+    def _read_sensors(self):
+        timestamp = time.time()
+        invalid_score = -9999
+
+        sensor_data = {
+            "timestamp": timestamp,
+            "ambient": invalid_score,
+            "pressure": invalid_score,
+            "temperature": invalid_score,
+            "humidity": invalid_score,
+            "invalid_sensors": [],
+        }
+
+        try:
+            ambient_light = self.sensor_VEML7700.readData()
+            sensor_data["ambient"] = ambient_light
+        except Exception as e:
+            sensor_data["invalid_sensors"].append("VEML7700")
+
+        try:
+            pressure, temp = self.sensor_Omron2smpd02e.readData()
+            sensor_data["pressure"] = pressure
+            sensor_data["temperature"] = temp
+        except Exception as e:
+            sensor_data["invalid_sensors"].append("Omron2smpd02e")
+
+        try:
+            data = self.sensor_SHT3x.readData()
+            sensor_data["temperature"] = round(data[0], 1)
+            sensor_data["humidity"] = round(data[1], 1)
+        except Exception as e:
+            sensor_data["invalid_sensors"].append("SHT3x")
+
+        return sensor_data
+
+    def run(self):
+        # To gracefully stop, check self.running periodically
+        remaining_seconds = 0
+        while self.running:
+            actfw_core.heartbeat()
+            if remaining_seconds == 0:
+                sensor_data = self._read_sensors()
+                actfw_core.notify([{"KSY_SmartSensor": sensor_data}])
+                remaining_seconds = self.interval
+            remaining_seconds -= 1
+            time.sleep(1)
 
 
-def read_sensors():
-    timestamp = time.time()
-    invalid_score = -9999
+def main():
+    app = actfw_core.Application()
 
-    sensor_data = {
-        "timestamp": timestamp,
-        "ambient": invalid_score,
-        "pressure": invalid_score,
-        "temperature": invalid_score,
-        "humidity": invalid_score,
-        "invalid_sensors": []
-    }
+    settings = app.get_settings({"send_interval": 60})
+    interval = settings["send_interval"]
 
-    try:
-        ambient_light = sensor_VEML7700.readData()
-        sensor_data['ambient'] = ambient_light
-    except Exception as e:
-        sensor_data['invalid_sensors'].append('VEML7700')
-
-    try:
-        pressure, temp = sensor_Omron2smpd02e.readData()
-        sensor_data['pressure'] = pressure
-        sensor_data['temperature'] = temp
-    except Exception as e:
-        sensor_data['invalid_sensors'].append('Omron2smpd02e')
-
-    try:
-        data = sensor_SHT3x.readData()
-        sensor_data['temperature'] = round(data[0], 1)
-        sensor_data['humidity'] = round(data[1], 1)
-    except Exception as e:
-        sensor_data['invalid_sensors'].append('SHT3x')
-
-    return sensor_data
+    app.register_task(Reader(interval))
+    app.run()
 
 
 if __name__ == "__main__":
-    app = actfw_core.Application()
-
-    settings = app.get_settings(
-        default_settings={
-            "send_interval": 5
-        }
-    )
-    interval_time = settings['send_interval']
-    try:
-        while True:
-            actfw_core.heartbeat()
-            sensor_data = read_sensors()
-            actfw_core.notify([{'KSY_SmartSensor': sensor_data}])
-            time.sleep(interval_time)
-    except KeyboardInterrupt:
-        print("Program stopped")
+    main()

--- a/i2c-sensor/setting_schema.json
+++ b/i2c-sensor/setting_schema.json
@@ -1,17 +1,14 @@
-
 {
   "$schema": "https://actcast.io/schema/v8/setting_schema_schema.json",
   "type": "object",
   "properties": {
-       "send_interval": {
-           "title": "send_interval",
-           "description": "send_sensordata_interval",
-           "type": "integer",
-           "default": 60
-           }
+    "send_interval": {
+      "title": "send_interval",
+      "description": "send_sensordata_interval",
+      "type": "integer",
+      "default": 60,
+      "minimum": 1
+    }
   },
-  "required": 
-    [
-        "send_interval"
-    ]
+  "required": ["send_interval"]
 }


### PR DESCRIPTION
i2c-sensor 利用時、Act を Nothing にしたり他の Act に切り替えると Runtime error になる問題を解決します。