### PR TITLE
Add information for custom image build.

### DIFF
--- a/custom-image/README.md
+++ b/custom-image/README.md
@@ -22,6 +22,8 @@ Python 3.12 をインストールしたイメージをビルドし、そのイ�
 
 ```bash
 cd custom-image
+# 事前に QEMU を有効にする必要があります
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 # イメージのビルド (時間がかかります)
 docker buildx build --platform linux/amd64 -t ghcr.io/idein/custom-image-example --load .
 ```


### PR DESCRIPTION
カスタムイメージのビルド時、 `docker run --rm --privileged multiarch/qemu-user-static --reset -p yes` を事前に実行しておく必要があるようでしたので追記したいです。